### PR TITLE
Add cookieSecure middleware and update routes

### DIFF
--- a/server/middleware/cookieSecure.js
+++ b/server/middleware/cookieSecure.js
@@ -1,0 +1,12 @@
+const cookieSecure = (req, res, next) => {
+  res.cookie("exampleCookie", "exampleValue", {
+    sameSite: "none", // Set SameSite to None
+    secure: true, // Mark the cookie to be used with HTTPS only
+    httpOnly: true, // Optional: Increases security by restricting access to the cookie from JavaScript
+    maxAge: 3600000, // Sets the cookie to expire after 1 hour (value in milliseconds)
+  });
+
+  next();
+};
+
+export default cookieSecure;

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,16 +1,26 @@
-import express from 'express';
-import { getPosts, getPost, getPostsBySearch, createPost, updatePost, deletePost, likePost, commentPost } from '../controllers/posts.js';
-import auth from '../middleware/auth.js';
+import express from "express";
+import {
+  getPosts,
+  getPost,
+  getPostsBySearch,
+  createPost,
+  updatePost,
+  deletePost,
+  likePost,
+  commentPost,
+} from "../controllers/posts.js";
+import auth from "../middleware/auth.js";
+import cookieSecure from "../middleware/cookieSecure.js";
 
 const router = express.Router();
 
-router.get('/search', getPostsBySearch);
-router.get('/', getPosts);
-router.get('/:id', getPost);
-router.post('/', auth, createPost);
-router.patch('/:id', auth, updatePost);
-router.delete('/:id', auth, deletePost);
-router.patch('/:id/likePost', auth, likePost);
-router.post('/:id/commentPost', auth, commentPost);
+router.get("/search", getPostsBySearch);
+router.get("/", cookieSecure, getPosts);
+router.get("/:id", getPost);
+router.post("/", auth, createPost);
+router.patch("/:id", auth, updatePost);
+router.delete("/:id", auth, deletePost);
+router.patch("/:id/likePost", auth, likePost);
+router.post("/:id/commentPost", auth, commentPost);
 
 export default router;


### PR DESCRIPTION
Add cookieSecure middleware and update routes, fixing the warning of third-party cookie will be blocked. Learn more in the Issues tab.